### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 setting.py
+


### PR DESCRIPTION
#Descripción 
¿Qué a cambiado?
Agregamos al gitignore soporte para Node.js
- [] Frontend
- [] Backend
- [x] Server 

#¿Cómo puedo probar los cambios?
Los archivos y la carpeta node_modulos ya no se suben al repositorio, ver el archivo gitignore completo.
